### PR TITLE
correctly display the step numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,5 +61,6 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.7",
     "accessible-astro-components": "^4.1.2"
-  }
+  },
+  "packageManager": "pnpm@10.13.1+sha512.37ebf1a5c7a30d5fabe0c5df44ee8da4c965ca0c5af3dbab28c3a1681b70a256218d05c81c9c0dcf767ef6b8551eb5b960042b9ed4300c59242336377e01cfad"
 }

--- a/src/components/Feature.astro
+++ b/src/components/Feature.astro
@@ -83,21 +83,22 @@ const { icon = 'mdi:rocket', title = 'Title', number }: Props = Astro.props
     height: 4rem;
   }
 
-  .step-number {
+    .step-number {
     position: absolute;
-    top: 1rem;
-    right: 1rem;
+    top: -0.5rem;
+    right: -0.5rem;
     z-index: 3;
     background-color: var(--link-color);
     color: var(--background-color);
     border-radius: 50%;
-    width: 2rem;
-    height: 2rem;
+    width: 3rem;
+    height: 3rem;
     display: flex;
     align-items: center;
     justify-content: center;
     font-weight: bold;
-    font-size: 1.25rem;
+    font-size: 1.5rem;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
   }
 
   :global(.feature [data-icon]) {

--- a/src/components/Feature.astro
+++ b/src/components/Feature.astro
@@ -24,16 +24,18 @@ interface Props {
 const { icon = 'mdi:rocket', title = 'Title', number }: Props = Astro.props
 ---
 
-<div class="feature flex flex-col gap-4">
+<div class="feature">
   {number && <span class="step-number">{number}</span>}
-  <div class="icon-container">
-    <Icon name={icon} />
-  </div>
-  <div class="content">
-    <h3 class="text-2xl font-bold">{title}</h3>
-    <p>
-      <slot>Lorem ipsum dolor sit amet consectetur adipisicing elit. Hic, corporis.</slot>
-    </p>
+  <div class="feature-content">
+    <div class="icon-container">
+      <Icon name={icon} />
+    </div>
+    <div class="content">
+      <h3 class="text-2xl font-bold">{title}</h3>
+      <p>
+        <slot>Lorem ipsum dolor sit amet consectetur adipisicing elit. Hic, corporis.</slot>
+      </p>
+    </div>
   </div>
 </div>
 

--- a/src/components/Feature.astro
+++ b/src/components/Feature.astro
@@ -42,7 +42,7 @@ const { icon = 'mdi:rocket', title = 'Title', number }: Props = Astro.props
 <style lang="scss">
   @use '../assets/scss/base/breakpoint' as *;
 
-    .feature {
+      .feature {
     position: relative;
     padding: var(--space-l);
     inline-size: calc(100% - var(--space-l));
@@ -55,13 +55,6 @@ const { icon = 'mdi:rocket', title = 'Title', number }: Props = Astro.props
     @include breakpoint(xl) {
       inline-size: 100%;
     }
-  }
-
-  .feature-content {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    padding-right: 2rem;
 
     &::before,
     &::after {
@@ -84,6 +77,13 @@ const { icon = 'mdi:rocket', title = 'Title', number }: Props = Astro.props
       border-radius: var(--radius-l);
       background-color: var(--link-color);
     }
+  }
+
+  .feature-content {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding-right: 2rem;
   }
 
   .icon-container {

--- a/src/components/Feature.astro
+++ b/src/components/Feature.astro
@@ -25,17 +25,19 @@ const { icon = 'mdi:rocket', title = 'Title', number }: Props = Astro.props
 ---
 
 <div class="feature">
-  {number && <span class="step-number">{number}</span>}
-  <div class="feature-content">
-    <div class="icon-container">
-      <Icon name={icon} />
+  <div class="feature-layout">
+    <div class="feature-content">
+      <div class="icon-container">
+        <Icon name={icon} />
+      </div>
+      <div class="content">
+        <h3 class="text-2xl font-bold">{title}</h3>
+        <p>
+          <slot>Lorem ipsum dolor sit amet consectetur adipisicing elit. Hic, corporis.</slot>
+        </p>
+      </div>
     </div>
-    <div class="content">
-      <h3 class="text-2xl font-bold">{title}</h3>
-      <p>
-        <slot>Lorem ipsum dolor sit amet consectetur adipisicing elit. Hic, corporis.</slot>
-      </p>
-    </div>
+    {number && <span class="step-number">{number}</span>}
   </div>
 </div>
 

--- a/src/components/Feature.astro
+++ b/src/components/Feature.astro
@@ -81,11 +81,18 @@ const { icon = 'mdi:rocket', title = 'Title', number }: Props = Astro.props
     }
   }
 
+    .feature-layout {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
   .feature-content {
     display: flex;
     flex-direction: column;
     gap: 1rem;
-    padding-right: 2rem;
+    flex: 1;
   }
 
   .icon-container {
@@ -94,11 +101,7 @@ const { icon = 'mdi:rocket', title = 'Title', number }: Props = Astro.props
     height: 4rem;
   }
 
-    .step-number {
-    position: absolute;
-    top: -0.5rem;
-    right: -0.5rem;
-    z-index: 3;
+  .step-number {
     background-color: var(--link-color);
     color: var(--background-color);
     border-radius: 50%;
@@ -110,6 +113,7 @@ const { icon = 'mdi:rocket', title = 'Title', number }: Props = Astro.props
     font-weight: bold;
     font-size: 1.5rem;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+    flex-shrink: 0;
   }
 
   :global(.feature [data-icon]) {

--- a/src/components/Feature.astro
+++ b/src/components/Feature.astro
@@ -42,7 +42,7 @@ const { icon = 'mdi:rocket', title = 'Title', number }: Props = Astro.props
 <style lang="scss">
   @use '../assets/scss/base/breakpoint' as *;
 
-  .feature {
+    .feature {
     position: relative;
     padding: var(--space-l);
     inline-size: calc(100% - var(--space-l));
@@ -55,6 +55,13 @@ const { icon = 'mdi:rocket', title = 'Title', number }: Props = Astro.props
     @include breakpoint(xl) {
       inline-size: 100%;
     }
+  }
+
+  .feature-content {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding-right: 2rem;
 
     &::before,
     &::after {


### PR DESCRIPTION
**Feature.astro component:**
- Restructure HTML layout with new feature-layout and feature-content wrapper divs
- Move step-number positioning from absolute to flex layout
- Update step-number styling: increase size from 2rem to 3rem, font-size from 1.25rem to 1.5rem
- Add box-shadow and flex-shrink properties to step-number
- Introduce new CSS classes for improved layout structure using flexbox

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5b47ec92223c4cd7b44a73da24d0b21d/cosmos-oasis)

👀 [Preview Link](https://5b47ec92223c4cd7b44a73da24d0b21d-cosmos-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5b47ec92223c4cd7b44a73da24d0b21d</projectId>-->
<!--<branchName>cosmos-oasis</branchName>-->